### PR TITLE
Added hour and minute in filename.

### DIFF
--- a/client/app/src/main/java/org/faudroids/mrhyde/jekyll/JekyllManager.java
+++ b/client/app/src/main/java/org/faudroids/mrhyde/jekyll/JekyllManager.java
@@ -34,10 +34,10 @@ public class JekyllManager {
 			DIR_DRAFTS = "_drafts";
 
 	private static final Pattern
-			POST_TITLE_PATTERN = Pattern.compile("(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)(.+)\\..+"),
+			POST_TITLE_PATTERN = Pattern.compile("(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)-(\\d\\d)(.+)\\..+"),
 			DRAFT_TITLE_PATTERN = Pattern.compile("(.+)\\..+");
 
-	private static final DateFormat POST_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+	private static final DateFormat POST_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd-hh-mm");
 
 	private final Context context;
 	private final FileManager fileManager;


### PR DESCRIPTION
And why? Well, it helps when one posts several posts in one day. if hour and date is also present, in blog they show them up in publishing type order accurately. Else, alphabetical in one day.

Please consider merging this. It don't do any harm adding hours and minutes. Also, condider that I am not a Java programmer, Review the two lines I've changed. I believe I didn't messed up. Thanks for this awesome app